### PR TITLE
Add devcontainer with MySQL and Jupyter

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/devcontainers/python:3.12
+
+RUN pip install --no-cache-dir jupyter ipython-sql sqlalchemy pymysql

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "dj-scratch",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "forwardPorts": [8888],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-toolsai.jupyter"
+      ]
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/workspace:cached
+    command: sleep infinity
+    depends_on:
+      - db
+    networks:
+      - devcontainer
+  db:
+    image: mysql:8.0
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: example
+      MYSQL_DATABASE: dev
+    ports:
+      - "3306:3306"
+    networks:
+      - devcontainer
+
+networks:
+  devcontainer:
+    driver: bridge

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # dj-scratch
+
+## Development Container
+
+This project includes a VS Code development container definition that provides:
+
+- Python 3.12
+- Jupyter Notebook
+- MySQL database server
+- SQL magic for connecting to the database from notebooks
+
+To start Jupyter inside the container, run:
+
+```bash
+jupyter notebook --ip 0.0.0.0 --no-browser
+```
+
+In a notebook, load SQL magic and connect to the database:
+
+```python
+%load_ext sql
+%sql mysql+pymysql://root:example@db/dev
+```


### PR DESCRIPTION
## Summary
- setup VS Code dev container with Python 3.12 and Jupyter
- add MySQL service and enable SQL magic via ipython-sql
- document how to connect to the database from notebooks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae241eb25483209d008edfbaaa4fcc