### PR TITLE
Add SQL magic sample notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ In a notebook, load SQL magic and connect to the database:
 %load_ext sql
 %sql mysql+pymysql://root:example@db/dev
 ```
+
+A sample notebook demonstrating this setup is available at [notebooks/sql_magic_example.ipynb](notebooks/sql_magic_example.ipynb).

--- a/notebooks/sql_magic_example.ipynb
+++ b/notebooks/sql_magic_example.ipynb
@@ -1,0 +1,58 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# SQL Magic Connection Example\n",
+    "\n",
+    "This notebook demonstrates how to use the `sql` IPython magic to connect to a database and run queries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "load-ext",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext sql"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "connect",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%sql mysql+pymysql://root:example@db/dev"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "query",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql\n",
+    "SELECT 1 AS result;"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add Jupyter notebook demonstrating `sql` magic with a MySQL connection
- document location of the example notebook in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae26b368288320b66c38b1793862d9