### PR TITLE
Add SQL magic sample notebook

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,7 @@
 FROM mcr.microsoft.com/devcontainers/python:3.12
 
+RUN apt-get update \
+    && apt-get install -y default-mysql-client \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN pip install --no-cache-dir jupyter ipython-sql sqlalchemy pymysql

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
   "service": "app",
   "workspaceFolder": "/workspace",
   "forwardPorts": [8888],
+  "postStartCommand": "until mysqladmin ping -h $MYSQL_HOST --silent; do sleep 1; done && jupyter notebook --ip 0.0.0.0 --no-browser --allow-root &",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,6 +10,13 @@ services:
     command: sleep infinity
     depends_on:
       - db
+    environment:
+      MYSQL_HOST: db
+      MYSQL_PORT: 3306
+      MYSQL_USER: dev
+      MYSQL_PASSWORD: devpass
+      MYSQL_DATABASE: dev
+      DATABASE_URL: mysql+pymysql://dev:devpass@db/dev
     networks:
       - devcontainer
   db:
@@ -18,6 +25,8 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: example
       MYSQL_DATABASE: dev
+      MYSQL_USER: dev
+      MYSQL_PASSWORD: devpass
     ports:
       - "3306:3306"
     networks:

--- a/README.md
+++ b/README.md
@@ -9,15 +9,24 @@ This project includes a VS Code development container definition that provides:
 - MySQL database server
 - SQL magic for connecting to the database from notebooks
 
-To start Jupyter inside the container, run:
+When the container starts, a MySQL server and a Jupyter Notebook server are launched automatically. The notebook server is available on port 8888.
 
-```bash
-jupyter notebook --ip 0.0.0.0 --no-browser
-```
+Database connection details are provided via environment variables:
 
-In a notebook, load SQL magic and connect to the database:
+- `MYSQL_HOST`
+- `MYSQL_PORT`
+- `MYSQL_USER`
+- `MYSQL_PASSWORD`
+- `MYSQL_DATABASE`
+- `DATABASE_URL`
+
+In a notebook, load SQL magic and connect using the predefined `DATABASE_URL`:
 
 ```python
 %load_ext sql
-%sql mysql+pymysql://root:example@db/dev
+import os
+db_url = os.environ["DATABASE_URL"]
+%sql $db_url
 ```
+
+A sample notebook demonstrating this setup is available at [notebooks/sql_magic_example.ipynb](notebooks/sql_magic_example.ipynb).

--- a/notebooks/sql_magic_example.ipynb
+++ b/notebooks/sql_magic_example.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# SQL Magic Connection Example\n",
+    "\n",
+    "This notebook demonstrates how to use the `sql` IPython magic to connect to a database and run queries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "load-ext",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext sql"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "connect",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "db_url = os.environ['DATABASE_URL']\n",
+    "%sql $db_url\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "query",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sql\n",
+    "SELECT 1 AS result;"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add Jupyter notebook demonstrating `sql` magic with a MySQL connection
- document location of the example notebook in README
- start a Jupyter Notebook server automatically in the development container
- start MySQL server automatically and provide credentials via environment variables

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae26b368288320b66c38b1793862d9